### PR TITLE
Update/frr 10.1

### DIFF
--- a/frr-lab01/frr01.clab.yml
+++ b/frr-lab01/frr01.clab.yml
@@ -92,7 +92,7 @@ topology:
     minion:
       kind: linux
       mgmt-ipv4: 172.20.20.64
-      image: opennms/minion:32.0.6
+      image: opennms/minion:33.0.8
       binds:
         - minion/minion-config.yaml:/opt/minion/minion-config.yaml
         - minion/etc:/opt/minion-etc-overlay

--- a/frr-lab01/frr01.clab.yml
+++ b/frr-lab01/frr01.clab.yml
@@ -8,7 +8,7 @@ topology:
     router1:
       kind: linux
       mgmt-ipv4: 172.20.20.32
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router1/daemons:/etc/frr/daemons
         - router1/frr.conf:/etc/frr/frr.conf
@@ -16,7 +16,7 @@ topology:
     router2:
       kind: linux
       mgmt-ipv4: 172.20.20.33
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router2/daemons:/etc/frr/daemons
         - router2/frr.conf:/etc/frr/frr.conf
@@ -24,7 +24,7 @@ topology:
     router3:
       kind: linux
       mgmt-ipv4: 172.20.20.34
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router3/daemons:/etc/frr/daemons
         - router3/frr.conf:/etc/frr/frr.conf
@@ -32,7 +32,7 @@ topology:
     router4:
       kind: linux
       mgmt-ipv4: 172.20.20.35
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router4/daemons:/etc/frr/daemons
         - router4/frr.conf:/etc/frr/frr.conf
@@ -40,7 +40,7 @@ topology:
     router5:
       kind: linux
       mgmt-ipv4: 172.20.20.36
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router5/daemons:/etc/frr/daemons
         - router5/frr.conf:/etc/frr/frr.conf
@@ -48,7 +48,7 @@ topology:
     router6:
       kind: linux
       mgmt-ipv4: 172.20.20.37
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router6/daemons:/etc/frr/daemons
         - router6/frr.conf:/etc/frr/frr.conf
@@ -56,7 +56,7 @@ topology:
     router7:
       kind: linux
       mgmt-ipv4: 172.20.20.38
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router7/daemons:/etc/frr/daemons
         - router7/frr.conf:/etc/frr/frr.conf

--- a/frr-lab01/router1/frr.conf
+++ b/frr-lab01/router1/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router1

--- a/frr-lab01/router2/frr.conf
+++ b/frr-lab01/router2/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router2

--- a/frr-lab01/router3/frr.conf
+++ b/frr-lab01/router3/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router3

--- a/frr-lab01/router4/frr.conf
+++ b/frr-lab01/router4/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router4

--- a/frr-lab01/router5/frr.conf
+++ b/frr-lab01/router5/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router5

--- a/frr-lab01/router6/frr.conf
+++ b/frr-lab01/router6/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router6

--- a/frr-lab01/router7/frr.conf
+++ b/frr-lab01/router7/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router7

--- a/frr-lab02/frr02.clab.yml
+++ b/frr-lab02/frr02.clab.yml
@@ -8,21 +8,21 @@ topology:
     router1:
       kind: linux
       mgmt-ipv4: 172.20.20.32
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router1/daemons:/etc/frr/daemons
         - router1/frr.conf:/etc/frr/frr.conf
     router2:
       kind: linux
       mgmt-ipv4: 172.20.20.33
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router2/daemons:/etc/frr/daemons
         - router2/frr.conf:/etc/frr/frr.conf
     router3:
       kind: linux
       mgmt-ipv4: 172.20.20.34
-      image: quay.io/labmonkeys/frrouting:9.1.b3053
+      image: quay.io/labmonkeys/frrouting:10.1.b3304
       binds:
         - router3/daemons:/etc/frr/daemons
         - router3/frr.conf:/etc/frr/frr.conf

--- a/frr-lab02/router1/frr.conf
+++ b/frr-lab02/router1/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router1

--- a/frr-lab02/router2/frr.conf
+++ b/frr-lab02/router2/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router2

--- a/frr-lab02/router3/frr.conf
+++ b/frr-lab02/router3/frr.conf
@@ -1,4 +1,4 @@
-frr version 9.0.2_git
+frr version 10.1
 frr defaults traditional
 agentx
 hostname router3


### PR DESCRIPTION
Testing SNMP capabilities with the FRRouting 10.1 on Debian for IS-IS, OSPF and BGP support.